### PR TITLE
Update event-subsriber

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/gorilla/mux 104068abd5cf50032c57aecbf2b8ce5b0a08a2cb
 github.com/gorilla/websocket 2d1e4548da234d9cb742cc3628556fef86aafbac
 github.com/mitchellh/mapstructure a6ef2f080c66d0a2e94e97cf74f80f772855da63
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
-github.com/rancher/event-subscriber e9cea4a523af345b65cc80d4609a5e60b5efb0c4
+github.com/rancher/event-subscriber cdcd1659ec46128cf3118ae6c56ade83b220ff79
 github.com/rancher/go-rancher f0378de1178a553cfb64666c0281486f593f0f05
 github.com/Sirupsen/logrus 07d998d174c4e2dc90e2f1989a20724220bca1ff
 gopkg.in/yaml.v2 fc96f64724b16cf262e47fb355e6dcea3127beb5 https://github.com/rancher/yaml.git

--- a/vendor/github.com/rancher/event-subscriber/events/listener.go
+++ b/vendor/github.com/rancher/event-subscriber/events/listener.go
@@ -165,7 +165,9 @@ func (router *EventRouter) Stop() {
 }
 
 func (router *EventRouter) subscribeToEvents(subscribeURL string, accessKey string, secretKey string, data url.Values) (*websocket.Conn, error) {
-	dialer := &websocket.Dialer{}
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: time.Second * 30,
+	}
 	headers := http.Header{}
 	headers.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(accessKey+":"+secretKey)))
 	subscribeURL = subscribeURL + "?" + data.Encode()


### PR DESCRIPTION
Adds a timeout to initial websocket handshake. This should prevent an
issue where we see the service completely lock up. See the
corresponding event-subscriber commit for more details.

Addresses https://github.com/rancher/rancher/issues/9123