### PR TITLE
WIP: Changes needed to add install/uuid in metadata

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -154,6 +154,10 @@ func addDefaultToAnswers(answers Answers, versionedData *Interim) map[string]int
 		defaultAnswers["self"] = self
 	}
 
+	rancherInstallInfo := make(map[string]interface{})
+	rancherInstallInfo["uuid"] = INSTALL_UUID
+	defaultAnswers["install"] = rancherInstallInfo
+
 	answers[DEFAULT_KEY] = defaultAnswers
 	return defaultAnswers
 }


### PR DESCRIPTION
Changes needed to read install.uuid setting from rancher client and put it in every version of metadata
http://rancher-metadata/<version>/install/uuid

@ibuildthecloud  @cjellick  

To read setting from rancher-metadata container,  we needed to make some changes in cattle so that the agent containers can read public settings without needing any extra role. 

This is WIP because this depends on cattle:master 

This PR is part of https://github.com/rancher/rancher/issues/8790