### PR TITLE
WIP Fix needed when stack_uuid is set for standalone containers

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -75,14 +75,16 @@ func addClientToAnswers(answers Answers, defaultAnswers map[string]interface{}, 
 		self["container"] = c
 		if c["stack_uuid"] != nil {
 			self["stack"] = versionedData.UUIDToStack[c["stack_uuid"].(string)]
-			service := versionedData.UUIDToService[getServiceUUID(c["service_uuid"].(string), c["service_name"].(string))]
-			selfService := make(map[string]interface{})
-			// to exclude token from service
-			for k, v := range service {
-				selfService[k] = v
+			if c["service_uuid"] != nil {
+				service := versionedData.UUIDToService[getServiceUUID(c["service_uuid"].(string), c["service_name"].(string))]
+				selfService := make(map[string]interface{})
+				// to exclude token from service
+				for k, v := range service {
+					selfService[k] = v
+				}
+				service["token"] = nil
+				self["service"] = selfService
 			}
-			service["token"] = nil
-			self["service"] = selfService
 		}
 		if c["host_uuid"] != nil {
 			self["host"] = versionedData.UUIDToHost[c["host_uuid"].(string)]

--- a/generator.go
+++ b/generator.go
@@ -154,6 +154,10 @@ func addDefaultToAnswers(answers Answers, versionedData *Interim) map[string]int
 		defaultAnswers["self"] = self
 	}
 
+	rancherInstallInfo := make(map[string]interface{})
+	rancherInstallInfo["uuid"] = INSTALL_UUID
+	defaultAnswers["install"] = rancherInstallInfo
+
 	answers[DEFAULT_KEY] = defaultAnswers
 	return defaultAnswers
 }


### PR DESCRIPTION
For standalone_containers, service_uuid is nil, so added a check before we look up the service using the service_uuid for containers. Otherwise this thrown nil panic.

This is WIP because this depends on cattle:master (to add stack_uuid to container metadata)

This PR is part of rancher/rancher#8790